### PR TITLE
IOD-245 Restored search. Using only React Select options.

### DIFF
--- a/src/components/formik/inputs/LicenseDropdownControl.jsx
+++ b/src/components/formik/inputs/LicenseDropdownControl.jsx
@@ -1,5 +1,5 @@
 /**
- * @description Component used to populate options of Assigned Licenses in the add Licensee page
+ * @description (Currently unused.) Component used to populate options of Assigned Licenses in the add Licensee page
  * @param {Object}  props Contains title of software, how many are used (assigned), total licenses owned
  * @returns React component.
  */

--- a/src/components/formik/inputs/SelectChipFormikControl.jsx
+++ b/src/components/formik/inputs/SelectChipFormikControl.jsx
@@ -30,16 +30,7 @@ export const SelectChipFormikControl = (props) => {
               onChange={(values) =>
                 form.setFieldValue(
                   field.name,
-                  values.map((value) => {
-                    // Temporary object for value so .label is only the title string.
-                    // Otherwise sends React element to body, which fails JSON.stringify()
-                    const tempValue = {
-                      ...value,
-                    };
-
-                    tempValue.label = tempValue.title;
-                    return tempValue;
-                  }),
+                  values.map((value) => value),
                 )
               }
               className={disabled ? 'readOnly' : 'select'}
@@ -60,10 +51,21 @@ export const SelectChipFormikControl = (props) => {
                         ...originalOption,
                       };
 
-                      tempOption.label = tempOption.title;
+                      tempOption.fullLabel = tempOption.title;
                       return tempOption;
                     })
               }
+              getOptionLabel={(option) => `${option.fullLabel}`}
+              styles={{
+                option: (styles, { data }) => {
+                  if (data.remaining <= 0)
+                    return {
+                      ...styles,
+                      color: '#b5b5b5',
+                    };
+                  else return { ...styles };
+                },
+              }}
               options={options}
             />
           </BaseControl>

--- a/src/components/formik/inputs/SelectChipFormikControl.jsx
+++ b/src/components/formik/inputs/SelectChipFormikControl.jsx
@@ -63,7 +63,7 @@ export const SelectChipFormikControl = (props) => {
                       ...styles,
                       color: '#b5b5b5',
                     };
-                  else return { ...styles };
+                  return { ...styles };
                 },
               }}
               options={options}

--- a/src/hooks/useLicensees/licenseeFields.js
+++ b/src/hooks/useLicensees/licenseeFields.js
@@ -48,13 +48,8 @@ export const licenseeFields = [
 
       return data.map((option) => ({
         value: option.id,
-        label: (
-          <LicenseDropdownControl
-            title={option.title}
-            total={option.quantity}
-            used={option.__licenseeConnection__.length}
-          />
-        ),
+        fullLabel: `${option.title} (${option.__licenseeConnection__.length} assigned of ${option.quantity})`,
+        remaining: option.quantity - option.__licenseeConnection__.length,
         ...option,
       }));
     },


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Software search on Licensee add page now searches properly. 
- Removed use of custom component, deciding to use only React Select options.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested in local dev environment.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
